### PR TITLE
Tank Splash

### DIFF
--- a/FAP/include/FAP.hpp
+++ b/FAP/include/FAP.hpp
@@ -43,7 +43,7 @@ namespace FAP {
      * \brief Starts the simulation. You can run this function multiple times. Feel free to run once, get the state and keep running.
      * \param nFrames the number of frames to simulate. A negative number runs the sim until combat is over.
      */
-	template<bool tankSplash = false>
+  template<bool tankSplash = false>
     void simulate(int nFrames = 96); // = 24*4, 4 seconds on fastest
 
     /**
@@ -65,17 +65,17 @@ namespace FAP {
     static int distSquared(FAPUnit<UnitExtension> const &u1, const FAPUnit<UnitExtension> &u2);
     static bool isSuicideUnit(BWAPI::UnitType ut);
 
-	template<bool tankSplash>
+  template<bool tankSplash>
     void unitsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits);
 
     static void medicsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &friendlyUnits);
     bool suicideSim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits);
     
-	template<bool tankSplash>
-	void isimulate();
+  template<bool tankSplash>
+  void isimulate();
 
     static void unitDeath(FAPUnit<UnitExtension> &&fu, std::vector<FAPUnit<UnitExtension>> &itsFriendlies);
-	
+  
     static auto max(int a, int b) {
       int vars[2] = { a, b };
       return vars[b > a];
@@ -287,66 +287,66 @@ namespace FAP {
       else {
         dealDamage(*closestEnemy, fu.groundDamage, fu.groundDamageType);
 
-		if constexpr (tankSplash) {
-			if (fu.unitType == BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode) {
-				const int siegeTankBlastRadiusInner = fu.unitType.groundWeapon().innerSplashRadius();
-				const int siegeTankBlastRadiusMedian = fu.unitType.groundWeapon().medianSplashRadius();
-				const int siegeTankBlastRadiusOuter = fu.unitType.groundWeapon().outerSplashRadius();
-				const int siegeTankBlastRadiusInnerSquared = siegeTankBlastRadiusInner * siegeTankBlastRadiusInner;
-				const int siegeTankBlastRadiusMedianSquared = siegeTankBlastRadiusMedian * siegeTankBlastRadiusMedian;
-				const int siegeTankBlastRadiusOuterSquared = siegeTankBlastRadiusOuter * siegeTankBlastRadiusOuter;
+    if constexpr (tankSplash) {
+      if (fu.unitType == BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode) {
+        const int siegeTankBlastRadiusInner = fu.unitType.groundWeapon().innerSplashRadius();
+        const int siegeTankBlastRadiusMedian = fu.unitType.groundWeapon().medianSplashRadius();
+        const int siegeTankBlastRadiusOuter = fu.unitType.groundWeapon().outerSplashRadius();
+        const int siegeTankBlastRadiusInnerSquared = siegeTankBlastRadiusInner * siegeTankBlastRadiusInner;
+        const int siegeTankBlastRadiusMedianSquared = siegeTankBlastRadiusMedian * siegeTankBlastRadiusMedian;
+        const int siegeTankBlastRadiusOuterSquared = siegeTankBlastRadiusOuter * siegeTankBlastRadiusOuter;
 
-				/*
-				auto const underTaker = [](FAPUnit<UnitExtension> enemyIt, bool killed, std::vector<FAPUnit<UnitExtension>>& enemyUnits) {
-					if (enemyIt.health < 1) {
-						killed = true;
-						auto temp = enemyIt;
-						enemyIt = enemyUnits.back();
-						enemyUnits.pop_back();
-						unitDeath(std::move(temp), enemyUnits);
-					}
-					return;
-				};*/
+        /*
+        auto const underTaker = [](FAPUnit<UnitExtension> enemyIt, bool killed, std::vector<FAPUnit<UnitExtension>>& enemyUnits) {
+          if (enemyIt.health < 1) {
+            killed = true;
+            auto temp = enemyIt;
+            enemyIt = enemyUnits.back();
+            enemyUnits.pop_back();
+            unitDeath(std::move(temp), enemyUnits);
+          }
+          return;
+        };*/
 
-				for (auto enemyIt = enemyUnits.begin(); enemyIt != enemyUnits.end();) {
-					if (!enemyIt->flying && enemyIt != closestEnemy) {
-						bool killed = false;
-						auto const effectiveDistToClosestEnemySquared = distSquared(*closestEnemy, *enemyIt) / 4; // shell hit point to unit edge
-						auto underTaker = [&enemyIt, &killed, &enemyUnits]() {
-							if (enemyIt->health < 1) {
-								killed = true;
-								auto temp = *enemyIt;
-								*enemyIt = enemyUnits.back();
-								enemyUnits.pop_back();
-								unitDeath(std::move(temp), enemyUnits);
-							}
-							return;
-						};
+        for (auto enemyIt = enemyUnits.begin(); enemyIt != enemyUnits.end();) {
+          if (!enemyIt->flying && enemyIt != closestEnemy) {
+            bool killed = false;
+            auto const effectiveDistToClosestEnemySquared = distSquared(*closestEnemy, *enemyIt) / 4; // shell hit point to unit edge
+            auto underTaker = [&enemyIt, &killed, &enemyUnits]() {
+              if (enemyIt->health < 1) {
+                killed = true;
+                auto temp = *enemyIt;
+                *enemyIt = enemyUnits.back();
+                enemyUnits.pop_back();
+                unitDeath(std::move(temp), enemyUnits);
+              }
+              return;
+            };
 
-						if (effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusInnerSquared) { // inner
-							dealDamage(*enemyIt, fu.groundDamage, fu.groundDamageType);
-							underTaker();
-						}
-						else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusInnerSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusMedianSquared) { // median
-							dealDamage(*enemyIt, fu.groundDamage / 2, fu.groundDamageType);
-							underTaker();
-						}
-						else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusMedianSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusOuterSquared) { // outer
-							dealDamage(*enemyIt, fu.groundDamage / 4, fu.groundDamageType);
-							underTaker();
-						}
-						else { // unaffected
-							;
-						}
-						if (!killed) ++enemyIt;
+            if (effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusInnerSquared) { // inner
+              dealDamage(*enemyIt, fu.groundDamage, fu.groundDamageType);
+              underTaker();
+            }
+            else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusInnerSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusMedianSquared) { // median
+              dealDamage(*enemyIt, fu.groundDamage / 2, fu.groundDamageType);
+              underTaker();
+            }
+            else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusMedianSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusOuterSquared) { // outer
+              dealDamage(*enemyIt, fu.groundDamage / 4, fu.groundDamageType);
+              underTaker();
+            }
+            else { // unaffected
+              ;
+            }
+            if (!killed) ++enemyIt;
 
-					}
-					else ++enemyIt;
-				}
-			}
-		}
+          }
+          else ++enemyIt;
+        }
+      }
+    }
 
-		fu.attackCooldownRemaining =
+    fu.attackCooldownRemaining =
           fu.groundCooldown << static_cast<int>((fu.elevation != -1) & (closestEnemy->elevation != -1) & (closestEnemy->elevation > fu.elevation));
       }
 

--- a/FAP/include/FAP.hpp
+++ b/FAP/include/FAP.hpp
@@ -43,6 +43,7 @@ namespace FAP {
      * \brief Starts the simulation. You can run this function multiple times. Feel free to run once, get the state and keep running.
      * \param nFrames the number of frames to simulate. A negative number runs the sim until combat is over.
      */
+	template<bool tankSplash = false>
     void simulate(int nFrames = 96); // = 24*4, 4 seconds on fastest
 
     /**
@@ -63,12 +64,18 @@ namespace FAP {
     static void dealDamage(FAPUnit<UnitExtension> &fu, int damage, BWAPI::DamageType damageType);
     static int distSquared(FAPUnit<UnitExtension> const &u1, const FAPUnit<UnitExtension> &u2);
     static bool isSuicideUnit(BWAPI::UnitType ut);
+
+	template<bool tankSplash>
     void unitsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits);
+
     static void medicsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &friendlyUnits);
     bool suicideSim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits);
-    void isimulate();
-    static void unitDeath(FAPUnit<UnitExtension> &&fu, std::vector<FAPUnit<UnitExtension>> &itsFriendlies);
+    
+	template<bool tankSplash>
+	void isimulate();
 
+    static void unitDeath(FAPUnit<UnitExtension> &&fu, std::vector<FAPUnit<UnitExtension>> &itsFriendlies);
+	
     static auto max(int a, int b) {
       int vars[2] = { a, b };
       return vars[b > a];
@@ -152,6 +159,7 @@ namespace FAP {
   }
 
   template<typename UnitExtension>
+  template<bool tankSplash>
   void FastAPproximation<UnitExtension>::simulate(int nFrames) {
     while (nFrames--) {
       if (player1.empty() || player2.empty())
@@ -159,7 +167,7 @@ namespace FAP {
 
       didSomething = false;
 
-      isimulate();
+      isimulate<tankSplash>();
 
       if (!didSomething)
         break;
@@ -224,6 +232,7 @@ namespace FAP {
   }
 
   template<typename UnitExtension>
+  template<bool tankSplash>
   void FastAPproximation<UnitExtension>::unitsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits) {
     if (fu.attackCooldownRemaining) {
       didSomething = true;
@@ -277,7 +286,67 @@ namespace FAP {
       }
       else {
         dealDamage(*closestEnemy, fu.groundDamage, fu.groundDamageType);
-        fu.attackCooldownRemaining =
+
+		if constexpr (tankSplash) {
+			if (fu.unitType == BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode) {
+				const int siegeTankBlastRadiusInner = fu.unitType.groundWeapon().innerSplashRadius();
+				const int siegeTankBlastRadiusMedian = fu.unitType.groundWeapon().medianSplashRadius();
+				const int siegeTankBlastRadiusOuter = fu.unitType.groundWeapon().outerSplashRadius();
+				const int siegeTankBlastRadiusInnerSquared = siegeTankBlastRadiusInner * siegeTankBlastRadiusInner;
+				const int siegeTankBlastRadiusMedianSquared = siegeTankBlastRadiusMedian * siegeTankBlastRadiusMedian;
+				const int siegeTankBlastRadiusOuterSquared = siegeTankBlastRadiusOuter * siegeTankBlastRadiusOuter;
+
+				/*
+				auto const underTaker = [](FAPUnit<UnitExtension> enemyIt, bool killed, std::vector<FAPUnit<UnitExtension>>& enemyUnits) {
+					if (enemyIt.health < 1) {
+						killed = true;
+						auto temp = enemyIt;
+						enemyIt = enemyUnits.back();
+						enemyUnits.pop_back();
+						unitDeath(std::move(temp), enemyUnits);
+					}
+					return;
+				};*/
+
+				for (auto enemyIt = enemyUnits.begin(); enemyIt != enemyUnits.end();) {
+					if (!enemyIt->flying && enemyIt != closestEnemy) {
+						bool killed = false;
+						auto const effectiveDistToClosestEnemySquared = distSquared(*closestEnemy, *enemyIt) / 4; // shell hit point to unit edge
+						auto underTaker = [&enemyIt, &killed, &enemyUnits]() {
+							if (enemyIt->health < 1) {
+								killed = true;
+								auto temp = *enemyIt;
+								*enemyIt = enemyUnits.back();
+								enemyUnits.pop_back();
+								unitDeath(std::move(temp), enemyUnits);
+							}
+							return;
+						};
+
+						if (effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusInnerSquared) { // inner
+							dealDamage(*enemyIt, fu.groundDamage, fu.groundDamageType);
+							underTaker();
+						}
+						else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusInnerSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusMedianSquared) { // median
+							dealDamage(*enemyIt, fu.groundDamage / 2, fu.groundDamageType);
+							underTaker();
+						}
+						else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusMedianSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusOuterSquared) { // outer
+							dealDamage(*enemyIt, fu.groundDamage / 4, fu.groundDamageType);
+							underTaker();
+						}
+						else { // unaffected
+							;
+						}
+						if (!killed) ++enemyIt;
+
+					}
+					else ++enemyIt;
+				}
+			}
+		}
+
+		fu.attackCooldownRemaining =
           fu.groundCooldown << static_cast<int>((fu.elevation != -1) & (closestEnemy->elevation != -1) & (closestEnemy->elevation > fu.elevation));
       }
 
@@ -387,6 +456,7 @@ namespace FAP {
   }
 
   template<typename UnitExtension>
+  template<bool tankSplash>
   void FastAPproximation<UnitExtension>::isimulate() {
     const auto simUnit = [this](auto &unit, auto &friendly, auto &enemy) {
       if (isSuicideUnit(unit->unitType)) {
@@ -399,7 +469,7 @@ namespace FAP {
         if (unit->unitType == BWAPI::UnitTypes::Terran_Medic)
           medicsim(*unit, friendly);
         else
-          unitsim(*unit, enemy);
+          unitsim<tankSplash>(*unit, enemy);
         ++unit;
       }
     };

--- a/FAP/include/FAP.hpp
+++ b/FAP/include/FAP.hpp
@@ -43,7 +43,7 @@ namespace FAP {
      * \brief Starts the simulation. You can run this function multiple times. Feel free to run once, get the state and keep running.
      * \param nFrames the number of frames to simulate. A negative number runs the sim until combat is over.
      */
-  template<bool tankSplash = false>
+    template<bool tankSplash = false>
     void simulate(int nFrames = 96); // = 24*4, 4 seconds on fastest
 
     /**
@@ -65,14 +65,14 @@ namespace FAP {
     static int distSquared(FAPUnit<UnitExtension> const &u1, const FAPUnit<UnitExtension> &u2);
     static bool isSuicideUnit(BWAPI::UnitType ut);
 
-  template<bool tankSplash>
+    template<bool tankSplash>
     void unitsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits);
 
     static void medicsim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &friendlyUnits);
     bool suicideSim(FAPUnit<UnitExtension> &fu, std::vector<FAPUnit<UnitExtension>> &enemyUnits);
     
-  template<bool tankSplash>
-  void isimulate();
+    template<bool tankSplash>
+    void isimulate();
 
     static void unitDeath(FAPUnit<UnitExtension> &&fu, std::vector<FAPUnit<UnitExtension>> &itsFriendlies);
   
@@ -287,66 +287,50 @@ namespace FAP {
       else {
         dealDamage(*closestEnemy, fu.groundDamage, fu.groundDamageType);
 
-    if constexpr (tankSplash) {
-      if (fu.unitType == BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode) {
-        const int siegeTankBlastRadiusInner = fu.unitType.groundWeapon().innerSplashRadius();
-        const int siegeTankBlastRadiusMedian = fu.unitType.groundWeapon().medianSplashRadius();
-        const int siegeTankBlastRadiusOuter = fu.unitType.groundWeapon().outerSplashRadius();
-        const int siegeTankBlastRadiusInnerSquared = siegeTankBlastRadiusInner * siegeTankBlastRadiusInner;
-        const int siegeTankBlastRadiusMedianSquared = siegeTankBlastRadiusMedian * siegeTankBlastRadiusMedian;
-        const int siegeTankBlastRadiusOuterSquared = siegeTankBlastRadiusOuter * siegeTankBlastRadiusOuter;
+        if constexpr (tankSplash) {
+          if (fu.unitType == BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode) {
+            const int siegeTankBlastRadiusInner = fu.unitType.groundWeapon().innerSplashRadius();
+            const int siegeTankBlastRadiusMedian = fu.unitType.groundWeapon().medianSplashRadius();
+            const int siegeTankBlastRadiusOuter = fu.unitType.groundWeapon().outerSplashRadius();
+            const int siegeTankBlastRadiusInnerSquared = siegeTankBlastRadiusInner * siegeTankBlastRadiusInner;
+            const int siegeTankBlastRadiusMedianSquared = siegeTankBlastRadiusMedian * siegeTankBlastRadiusMedian;
+            const int siegeTankBlastRadiusOuterSquared = siegeTankBlastRadiusOuter * siegeTankBlastRadiusOuter;
 
-        /*
-        auto const underTaker = [](FAPUnit<UnitExtension> enemyIt, bool killed, std::vector<FAPUnit<UnitExtension>>& enemyUnits) {
-          if (enemyIt.health < 1) {
-            killed = true;
-            auto temp = enemyIt;
-            enemyIt = enemyUnits.back();
-            enemyUnits.pop_back();
-            unitDeath(std::move(temp), enemyUnits);
-          }
-          return;
-        };*/
+            for (auto enemyIt = enemyUnits.begin(); enemyIt != enemyUnits.end();) {
+              if (!enemyIt->flying && enemyIt != closestEnemy) {
+                bool killed = false;
+                auto const effectiveDistToClosestEnemySquared = distSquared(*closestEnemy, *enemyIt) / 4; // shell hit point to unit edge
+                auto underTaker = [&]() {
+                  if (enemyIt->health < 1) {
+                    killed = true;
+                    auto temp = *enemyIt;
+                    *enemyIt = enemyUnits.back();
+                    enemyUnits.pop_back();
+                    unitDeath(std::move(temp), enemyUnits);
+                  }
+                  return;
+                };
 
-        for (auto enemyIt = enemyUnits.begin(); enemyIt != enemyUnits.end();) {
-          if (!enemyIt->flying && enemyIt != closestEnemy) {
-            bool killed = false;
-            auto const effectiveDistToClosestEnemySquared = distSquared(*closestEnemy, *enemyIt) / 4; // shell hit point to unit edge
-            auto underTaker = [&enemyIt, &killed, &enemyUnits]() {
-              if (enemyIt->health < 1) {
-                killed = true;
-                auto temp = *enemyIt;
-                *enemyIt = enemyUnits.back();
-                enemyUnits.pop_back();
-                unitDeath(std::move(temp), enemyUnits);
+                if (effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusInnerSquared) { // inner
+                  dealDamage(*enemyIt, fu.groundDamage, fu.groundDamageType);
+                  underTaker();
+                }
+                else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusInnerSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusMedianSquared) { // median
+                  dealDamage(*enemyIt, fu.groundDamage / 2, fu.groundDamageType);
+                  underTaker();
+                }
+                else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusMedianSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusOuterSquared) { // outer
+                  dealDamage(*enemyIt, fu.groundDamage / 4, fu.groundDamageType);
+                  underTaker();
+                }
+                if (!killed) ++enemyIt;
               }
-              return;
-            };
-
-            if (effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusInnerSquared) { // inner
-              dealDamage(*enemyIt, fu.groundDamage, fu.groundDamageType);
-              underTaker();
+              else ++enemyIt;
             }
-            else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusInnerSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusMedianSquared) { // median
-              dealDamage(*enemyIt, fu.groundDamage / 2, fu.groundDamageType);
-              underTaker();
-            }
-            else if (effectiveDistToClosestEnemySquared > siegeTankBlastRadiusMedianSquared && effectiveDistToClosestEnemySquared <= siegeTankBlastRadiusOuterSquared) { // outer
-              dealDamage(*enemyIt, fu.groundDamage / 4, fu.groundDamageType);
-              underTaker();
-            }
-            else { // unaffected
-              ;
-            }
-            if (!killed) ++enemyIt;
-
           }
-          else ++enemyIt;
         }
-      }
-    }
 
-    fu.attackCooldownRemaining =
+        fu.attackCooldownRemaining =
           fu.groundCooldown << static_cast<int>((fu.elevation != -1) & (closestEnemy->elevation != -1) & (closestEnemy->elevation > fu.elevation));
       }
 

--- a/Tests/Combat.cpp
+++ b/Tests/Combat.cpp
@@ -2,122 +2,179 @@
 
 #include "gtest/gtest.h"
 
+#include <array>
+#include <utility>
+
 TEST(Combat, MarineTwoOnOne) {
-  {
-    FAP::FastAPproximation<> fap;
+	{
+		FAP::FastAPproximation<> fap;
 
-    for (int i = 0; i < 2; ++i)
-      fap.addUnitPlayer1(
-        testUnit(BWAPI::UnitTypes::Terran_Marine)
-        .setPosition({ 0, 0 })
-      );
+		for (int i = 0; i < 2; ++i)
+			fap.addUnitPlayer1(
+				testUnit(BWAPI::UnitTypes::Terran_Marine)
+				.setPosition({ 0, 0 })
+			);
 
-    fap.addUnitPlayer2(
-      testUnit(BWAPI::UnitTypes::Terran_Marine)
-      .setPosition({ 0, 0 })
-    );
+		fap.addUnitPlayer2(
+			testUnit(BWAPI::UnitTypes::Terran_Marine)
+			.setPosition({ 0, 0 })
+		);
 
-    fap.simulate(-1);
+		fap.simulate(-1);
 
-    // Two marines beat one
-    EXPECT_FALSE(fap.getState().first->empty());
-    EXPECT_TRUE(fap.getState().second->empty());
-  }
+		// Two marines beat one
+		EXPECT_FALSE(fap.getState().first->empty());
+		EXPECT_TRUE(fap.getState().second->empty());
+	}
 }
 
 TEST(Combat, MarineOnZealot) {
-  FAP::FastAPproximation<> fap;
+	FAP::FastAPproximation<> fap;
 
-  fap.addUnitPlayer1(
-    testUnit(BWAPI::UnitTypes::Protoss_Zealot)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer1(
+		testUnit(BWAPI::UnitTypes::Protoss_Zealot)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.addUnitPlayer2(
-    testUnit(BWAPI::UnitTypes::Terran_Marine)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer2(
+		testUnit(BWAPI::UnitTypes::Terran_Marine)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.simulate(-1);
+	fap.simulate(-1);
 
-  // Zealot beats marine
-  EXPECT_FALSE(fap.getState().first->empty());
-  EXPECT_TRUE(fap.getState().second->empty());
+	// Zealot beats marine
+	EXPECT_FALSE(fap.getState().first->empty());
+	EXPECT_TRUE(fap.getState().second->empty());
 }
 
 TEST(Combat, MarineOnZergling) {
-  FAP::FastAPproximation<> fap;
+	FAP::FastAPproximation<> fap;
 
-  fap.addUnitPlayer1(
-    testUnit(BWAPI::UnitTypes::Zerg_Zergling)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer1(
+		testUnit(BWAPI::UnitTypes::Zerg_Zergling)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.addUnitPlayer2(
-    testUnit(BWAPI::UnitTypes::Terran_Marine)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer2(
+		testUnit(BWAPI::UnitTypes::Terran_Marine)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.simulate(-1);
+	fap.simulate(-1);
 
-  // Zerling beats marine
-  EXPECT_FALSE(fap.getState().first->empty());
-  EXPECT_TRUE(fap.getState().second->empty());
+	// Zerling beats marine
+	EXPECT_FALSE(fap.getState().first->empty());
+	EXPECT_TRUE(fap.getState().second->empty());
 }
 
 TEST(Combat, MarineFiringAtValkyrie) {
-  FAP::FastAPproximation<> fap;
+	FAP::FastAPproximation<> fap;
 
-  fap.addUnitPlayer1(
-    testUnit(BWAPI::UnitTypes::Terran_Marine)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer1(
+		testUnit(BWAPI::UnitTypes::Terran_Marine)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.addUnitPlayer2(
-    testUnit(BWAPI::UnitTypes::Terran_Valkyrie)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer2(
+		testUnit(BWAPI::UnitTypes::Terran_Valkyrie)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.simulate(1);
+	fap.simulate(1);
 
-  // Marine does 6-2 damage to valkyrie
-  EXPECT_EQ(fap.getState().second->front().health, fap.getState().second->front().maxHealth - (4 << 8));
+	// Marine does 6-2 damage to valkyrie
+	EXPECT_EQ(fap.getState().second->front().health, fap.getState().second->front().maxHealth - (4 << 8));
 }
 
 TEST(Combat, StackedTank) {
-  FAP::FastAPproximation<> fap;
+	FAP::FastAPproximation<> fap;
 
-  fap.addUnitPlayer1(
-    testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer1(
+		testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.addUnitPlayer2(
-    testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer2(
+		testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.simulate(-1);
+	fap.simulate(-1);
 
-  EXPECT_FALSE(fap.getState().first->empty());
-  EXPECT_TRUE(fap.getState().second->empty());
+	EXPECT_FALSE(fap.getState().first->empty());
+	EXPECT_TRUE(fap.getState().second->empty());
 }
 
 TEST(Combat, NonStackedTank) {
-  FAP::FastAPproximation<> fap;
+	FAP::FastAPproximation<> fap;
 
-  fap.addUnitPlayer1(
-    testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
-    .setPosition({ 0, 0 })
-  );
+	fap.addUnitPlayer1(
+		testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
+		.setPosition({ 0, 0 })
+	);
 
-  fap.addUnitPlayer2(
-    testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
-    .setPosition({ 1000, 0 })
-  );
+	fap.addUnitPlayer2(
+		testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
+		.setPosition({ 1000, 0 })
+	);
 
-  fap.simulate(-1);
+	fap.simulate(-1);
 
-  EXPECT_TRUE(fap.getState().first->empty());
-  EXPECT_FALSE(fap.getState().second->empty());
+	EXPECT_TRUE(fap.getState().first->empty());
+	EXPECT_FALSE(fap.getState().second->empty());
+}
+
+template<bool tankSplash, int maxDistanceBetweenUnits>
+int testTanks() {
+	FAP::FastAPproximation<> fap;
+
+	// Assumes the size of the map is at least 64 x 64
+	for (int i = 0; i < 2; ++i)
+		fap.addUnitPlayer1(
+			testUnit(BWAPI::UnitTypes::Zerg_Zergling)
+			.setPosition({ 1392, 992 + maxDistanceBetweenUnits * i })
+		);
+
+	fap.addUnitPlayer2(
+		testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
+		.setPosition({ 992, 992 })
+	);
+	
+	fap.simulate<tankSplash>(-1);
+	
+	int splashedLingRemainingHealth;
+	if constexpr (tankSplash) {
+		if constexpr(maxDistanceBetweenUnits <= 20)
+			splashedLingRemainingHealth = 0;
+		else if constexpr(maxDistanceBetweenUnits <= 50)
+			splashedLingRemainingHealth = 23;
+		else if constexpr(maxDistanceBetweenUnits <= 80)
+			splashedLingRemainingHealth = 32;
+		else
+			splashedLingRemainingHealth = 35;
+	}
+	else
+		splashedLingRemainingHealth = 35;
+
+	// check which player wins/loses
+	EXPECT_EQ(fap.getState().first->empty(), tankSplash && maxDistanceBetweenUnits <= 20);
+	EXPECT_EQ(fap.getState().second->empty(), !tankSplash || tankSplash && maxDistanceBetweenUnits > 20);
+
+	// check actual splash damage dealt (a function of maxDistanceBetweenUnits)
+	EXPECT_EQ(fap.getState().first->front().health >> 8, splashedLingRemainingHealth);
+	return 1;
+}
+
+template<bool tankSplash, typename T, T... I>
+std::array<T, sizeof...(I)> run_testTanks(std::integer_sequence<T, I...>)
+{
+	return{ testTanks<tankSplash, I>()... };
+}
+
+TEST(Combat, OneTankOnTwoLings) {
+	auto radiiSeq = std::integer_sequence<int, 20, 50, 80, 100>();
+	
+	run_testTanks<true>(radiiSeq);
+	run_testTanks<false>(radiiSeq);
 }

--- a/Tests/Combat.cpp
+++ b/Tests/Combat.cpp
@@ -6,175 +6,174 @@
 #include <utility>
 
 TEST(Combat, MarineTwoOnOne) {
-	{
-		FAP::FastAPproximation<> fap;
+  {
+    FAP::FastAPproximation<> fap;
 
-		for (int i = 0; i < 2; ++i)
-			fap.addUnitPlayer1(
-				testUnit(BWAPI::UnitTypes::Terran_Marine)
-				.setPosition({ 0, 0 })
-			);
+    for (int i = 0; i < 2; ++i)
+      fap.addUnitPlayer1(
+        testUnit(BWAPI::UnitTypes::Terran_Marine)
+        .setPosition({ 0, 0 })
+      );
 
-		fap.addUnitPlayer2(
-			testUnit(BWAPI::UnitTypes::Terran_Marine)
-			.setPosition({ 0, 0 })
-		);
+    fap.addUnitPlayer2(
+      testUnit(BWAPI::UnitTypes::Terran_Marine)
+      .setPosition({ 0, 0 })
+    );
 
-		fap.simulate(-1);
+    fap.simulate(-1);
 
-		// Two marines beat one
-		EXPECT_FALSE(fap.getState().first->empty());
-		EXPECT_TRUE(fap.getState().second->empty());
-	}
+    // Two marines beat one
+    EXPECT_FALSE(fap.getState().first->empty());
+    EXPECT_TRUE(fap.getState().second->empty());
+  }
 }
 
 TEST(Combat, MarineOnZealot) {
-	FAP::FastAPproximation<> fap;
+  FAP::FastAPproximation<> fap;
 
-	fap.addUnitPlayer1(
-		testUnit(BWAPI::UnitTypes::Protoss_Zealot)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer1(
+    testUnit(BWAPI::UnitTypes::Protoss_Zealot)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.addUnitPlayer2(
-		testUnit(BWAPI::UnitTypes::Terran_Marine)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer2(
+    testUnit(BWAPI::UnitTypes::Terran_Marine)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.simulate(-1);
+  fap.simulate(-1);
 
-	// Zealot beats marine
-	EXPECT_FALSE(fap.getState().first->empty());
-	EXPECT_TRUE(fap.getState().second->empty());
+  // Zealot beats marine
+  EXPECT_FALSE(fap.getState().first->empty());
+  EXPECT_TRUE(fap.getState().second->empty());
 }
 
 TEST(Combat, MarineOnZergling) {
-	FAP::FastAPproximation<> fap;
+  FAP::FastAPproximation<> fap;
 
-	fap.addUnitPlayer1(
-		testUnit(BWAPI::UnitTypes::Zerg_Zergling)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer1(
+    testUnit(BWAPI::UnitTypes::Zerg_Zergling)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.addUnitPlayer2(
-		testUnit(BWAPI::UnitTypes::Terran_Marine)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer2(
+    testUnit(BWAPI::UnitTypes::Terran_Marine)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.simulate(-1);
+  fap.simulate(-1);
 
-	// Zerling beats marine
-	EXPECT_FALSE(fap.getState().first->empty());
-	EXPECT_TRUE(fap.getState().second->empty());
+  // Zerling beats marine
+  EXPECT_FALSE(fap.getState().first->empty());
+  EXPECT_TRUE(fap.getState().second->empty());
 }
 
 TEST(Combat, MarineFiringAtValkyrie) {
-	FAP::FastAPproximation<> fap;
+  FAP::FastAPproximation<> fap;
 
-	fap.addUnitPlayer1(
-		testUnit(BWAPI::UnitTypes::Terran_Marine)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer1(
+    testUnit(BWAPI::UnitTypes::Terran_Marine)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.addUnitPlayer2(
-		testUnit(BWAPI::UnitTypes::Terran_Valkyrie)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer2(
+    testUnit(BWAPI::UnitTypes::Terran_Valkyrie)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.simulate(1);
+  fap.simulate(1);
 
-	// Marine does 6-2 damage to valkyrie
-	EXPECT_EQ(fap.getState().second->front().health, fap.getState().second->front().maxHealth - (4 << 8));
+  // Marine does 6-2 damage to valkyrie
+  EXPECT_EQ(fap.getState().second->front().health, fap.getState().second->front().maxHealth - (4 << 8));
 }
 
 TEST(Combat, StackedTank) {
-	FAP::FastAPproximation<> fap;
+  FAP::FastAPproximation<> fap;
 
-	fap.addUnitPlayer1(
-		testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer1(
+    testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.addUnitPlayer2(
-		testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer2(
+    testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.simulate(-1);
+  fap.simulate(-1);
 
-	EXPECT_FALSE(fap.getState().first->empty());
-	EXPECT_TRUE(fap.getState().second->empty());
+  EXPECT_FALSE(fap.getState().first->empty());
+  EXPECT_TRUE(fap.getState().second->empty());
 }
 
 TEST(Combat, NonStackedTank) {
-	FAP::FastAPproximation<> fap;
+  FAP::FastAPproximation<> fap;
 
-	fap.addUnitPlayer1(
-		testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
-		.setPosition({ 0, 0 })
-	);
+  fap.addUnitPlayer1(
+    testUnit(BWAPI::UnitTypes::Protoss_Dragoon)
+    .setPosition({ 0, 0 })
+  );
 
-	fap.addUnitPlayer2(
-		testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
-		.setPosition({ 1000, 0 })
-	);
+  fap.addUnitPlayer2(
+    testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
+    .setPosition({ 1000, 0 })
+  );
 
-	fap.simulate(-1);
+  fap.simulate(-1);
 
-	EXPECT_TRUE(fap.getState().first->empty());
-	EXPECT_FALSE(fap.getState().second->empty());
+  EXPECT_TRUE(fap.getState().first->empty());
+  EXPECT_FALSE(fap.getState().second->empty());
 }
 
 template<bool tankSplash, int maxDistanceBetweenUnits>
 int testTanks() {
-	FAP::FastAPproximation<> fap;
+  FAP::FastAPproximation<> fap;
 
-	// Assumes the size of the map is at least 64 x 64
-	for (int i = 0; i < 2; ++i)
-		fap.addUnitPlayer1(
-			testUnit(BWAPI::UnitTypes::Zerg_Zergling)
-			.setPosition({ 1392, 992 + maxDistanceBetweenUnits * i })
-		);
+  // Assumes the size of the map is at least 64 x 64
+  for (int i = 0; i < 2; ++i)
+    fap.addUnitPlayer1(
+      testUnit(BWAPI::UnitTypes::Zerg_Zergling)
+      .setPosition({ 1392, 992 + maxDistanceBetweenUnits * i })
+    );
 
-	fap.addUnitPlayer2(
-		testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
-		.setPosition({ 992, 992 })
-	);
-	
-	fap.simulate<tankSplash>(-1);
-	
-	int splashedLingRemainingHealth;
-	if constexpr (tankSplash) {
-		if constexpr(maxDistanceBetweenUnits <= 20)
-			splashedLingRemainingHealth = 0;
-		else if constexpr(maxDistanceBetweenUnits <= 50)
-			splashedLingRemainingHealth = 23;
-		else if constexpr(maxDistanceBetweenUnits <= 80)
-			splashedLingRemainingHealth = 32;
-		else
-			splashedLingRemainingHealth = 35;
-	}
-	else
-		splashedLingRemainingHealth = 35;
+  fap.addUnitPlayer2(
+    testUnit(BWAPI::UnitTypes::Terran_Siege_Tank_Siege_Mode)
+    .setPosition({ 992, 992 })
+  );
+  
+  fap.simulate<tankSplash>(-1);
+  
+  int splashedLingRemainingHealth;
+  if constexpr (tankSplash) {
+    if constexpr(maxDistanceBetweenUnits <= 20)
+      splashedLingRemainingHealth = 0;
+    else if constexpr(maxDistanceBetweenUnits <= 50)
+      splashedLingRemainingHealth = 23;
+    else if constexpr(maxDistanceBetweenUnits <= 80)
+      splashedLingRemainingHealth = 32;
+    else
+      splashedLingRemainingHealth = 35;
+  }
+  else
+    splashedLingRemainingHealth = 35;
 
-	// check which player wins/loses
-	EXPECT_EQ(fap.getState().first->empty(), tankSplash && maxDistanceBetweenUnits <= 20);
-	EXPECT_EQ(fap.getState().second->empty(), !tankSplash || tankSplash && maxDistanceBetweenUnits > 20);
+  // check which player wins/loses
+  EXPECT_EQ(fap.getState().first->empty(), tankSplash && maxDistanceBetweenUnits <= 20);
+  EXPECT_EQ(fap.getState().second->empty(), !tankSplash || tankSplash && maxDistanceBetweenUnits > 20);
 
-	// check actual splash damage dealt (a function of maxDistanceBetweenUnits)
-	EXPECT_EQ(fap.getState().first->front().health >> 8, splashedLingRemainingHealth);
-	return 1;
+  // check actual splash damage dealt (a function of maxDistanceBetweenUnits)
+  EXPECT_EQ(fap.getState().first->front().health >> 8, splashedLingRemainingHealth);
+  return 1;
 }
 
 template<bool tankSplash, typename T, T... I>
-std::array<T, sizeof...(I)> run_testTanks(std::integer_sequence<T, I...>)
-{
-	return{ testTanks<tankSplash, I>()... };
+std::array<T, sizeof...(I)> run_testTanks(std::integer_sequence<T, I...>) {
+  return{ testTanks<tankSplash, I>()... };
 }
 
 TEST(Combat, OneTankOnTwoLings) {
-	auto radiiSeq = std::integer_sequence<int, 20, 50, 80, 100>();
-	
-	run_testTanks<true>(radiiSeq);
-	run_testTanks<false>(radiiSeq);
+  auto radiiSeq = std::integer_sequence<int, 20, 50, 80, 100>();
+  
+  run_testTanks<true>(radiiSeq);
+  run_testTanks<false>(radiiSeq);
 }


### PR DESCRIPTION
- Added support for siege tank splash damage computation.
- Added a test (OneTankOnTwoLings) to exhaustively test the newly-added feature, with and without splash, and considering different splash radii.